### PR TITLE
Update debug module and devDependencies that generated warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cookie": "^0.3.1",
     "cookies": "^0.6.2",
     "crc": "3.4.4",
-    "debug": "2.6.0",
+    "debug": "^4.1.1",
     "depd": "~1.1.0",
     "on-headers": "~1.0.1",
     "parseurl": "~1.3.1",
@@ -23,13 +23,13 @@
   "devDependencies": {
     "after": "0.8.2",
     "cookie-parser": "1.4.3",
-    "express": "4.14.0",
-    "istanbul": "0.4.5",
+    "express": "^4.17.1",
+    "istanbul": "^0.4.5",
     "keygrip": "^1.0.1",
     "koa": "^1.2.4",
     "koa-generic-session": "^1.11.5",
-    "mocha": "2.5.3",
-    "supertest": "1.1.0"
+    "mocha": "^6.2.0",
+    "supertest": "^4.0.2"
   },
   "files": [
     "session/",
@@ -41,7 +41,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "mocha --bail --reporter spec test/",
+    "test": "mocha --bail --exit --reporter spec test/",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
     "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
   }


### PR DESCRIPTION
This is being done to silence the last audit warning on STESV-2400 - the older debug module is susceptible to regex DDOS issues. Updating this repo's vulnerable modules while I'm in here.