### PR TITLE
STCORE-1495 serialize expires as _expires

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+# JavaScript Node CircleCI 2.1 configuration file
+#
+# Check https://circleci.com/docs/2.1/language-javascript/ for more details
+#
+version: 2.1
+executors:
+  linux:
+    docker:
+      - image: cimg/base:2020.01
+        environment:
+          ENV: development
+
+  macos:
+    macos:
+      xcode: '13.2.1'
+    environment:
+        ENV: development
+
+orbs:
+  node: circleci/node@4.7.0
+
+jobs:
+  test:
+    parameters:
+      os:
+        type: executor
+      node-version:
+        type: string
+    executor: << parameters.os >>
+    steps:
+      - checkout
+      - node/install:
+          node-version: << parameters.node-version >>
+          npm-version: 6.14.14
+      - node/install-packages
+      - run:
+          command: npm run test
+
+workflows:
+  version: 2
+  matrix-tests:
+    jobs:
+      - test:
+          context: st-global
+          matrix:
+            parameters:
+              os: [linux, macos]
+              node-version: ['14.19.1']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,8 @@ jobs:
       - node/install:
           node-version: << parameters.node-version >>
           npm-version: 6.14.14
-      - node/install-packages
+      - node/install-packages:
+          override-ci-command: npm install
       - run:
           command: npm run test
 

--- a/session/cookie.js
+++ b/session/cookie.js
@@ -97,7 +97,10 @@ Cookie.prototype = {
   get data() {
     return {
         maxAge: this.originalMaxAge // what we want serialized in the session obj is called maxAge
-      , expires: this._expires
+      // having `expires` in the session breaks koa-generic-session, since it uses expires before maxAge. 
+      // see https://github.com/koajs/generic-session/blob/ffe3357069c642cfafab5610713563b10b725323/src/store.js#L56-L65
+      // SocialTables
+      , _expires: this._expires
       , secure: this.secure
       , httpOnly: this.httpOnly
       , domain: this.domain

--- a/session/memory.js
+++ b/session/memory.js
@@ -15,6 +15,7 @@
 
 var Store = require('./store')
 var util = require('util')
+var Cookie = require('./cookie')
 
 /**
  * Shim setImmediate for node.js < 0.10
@@ -171,9 +172,12 @@ function getSession(sessionId) {
   // parse
   sess = JSON.parse(sess)
 
-  var expires = typeof sess.cookie.expires === 'string'
-    ? new Date(sess.cookie.expires)
-    : sess.cookie.expires
+  //use the session/cookie object that has a getter for expires
+  var sessCookie = new Cookie(sess.cookie)
+
+  var expires = typeof sessCookie.expires === 'string'
+    ? new Date(sessCookie.expires)
+    : sessCookie.expires
 
   // destroy expired session
   if (expires && expires <= Date.now()) {

--- a/test/session.js
+++ b/test/session.js
@@ -416,7 +416,8 @@ describe('session()', function(){
           store.get(id, function (err, sess) {
             if (err) return done(err)
             assert.ok(sess, 'session saved to store')
-            var exp = new Date(sess.cookie.expires)
+            var sessionCookie = new Cookie(sess.cookie);
+            var exp = new Date(sessionCookie.expires)
             assert.equal(exp.toUTCString(), expires(res))
             setTimeout(function () {
               request(server)
@@ -426,9 +427,10 @@ describe('session()', function(){
                 if (err) return done(err)
                 store.get(id, function (err, sess) {
                   if (err) return done(err)
+                  var sessonCookie = new Cookie(sess.cookie);
                   assert.equal(res.text, id)
                   assert.ok(sess, 'session still in store')
-                  assert.notEqual(new Date(sess.cookie.expires).toUTCString(), exp.toUTCString(), 'session cookie expiration updated')
+                  assert.notEqual(new Date(sessonCookie.expires).toUTCString(), exp.toUTCString(), 'session cookie expiration updated')
                   done()
                 })
               })
@@ -1810,7 +1812,8 @@ describe('session()', function(){
         var id = sid(res)
         store.get(id, function (err, sess) {
           if (err) return done(err)
-          var exp = new Date(sess.cookie.expires)
+          var sessionCookie = new Cookie(sess.cookie);
+          var exp = new Date(sessionCookie.expires)
           setTimeout(function () {
             request(server)
             .get('/')
@@ -1819,7 +1822,8 @@ describe('session()', function(){
               if (err) return done(err);
               store.get(id, function (err, sess) {
                 if (err) return done(err)
-                assert.notEqual(new Date(sess.cookie.expires).getTime(), exp.getTime())
+                var sessionCookie = new Cookie(sess.cookie);
+                assert.notEqual(new Date(sessionCookie.expires).getTime(), exp.getTime())
                 done()
               })
             })


### PR DESCRIPTION
[STCORE-1495](https://jira.cvent.com/browse/STCORE-1495)

When we serialize both `maxAge` and `expires` into the redis session, it causes problems for koa-generic-session resetting the TTL in redis, which reads from `expires` before reading from `maxAge`.

Fortunately, connect-redis uses the session.cookie object from this library that has already been serialized. 

This PR serializes `expires` in redis as `cookie._expires`, which gets turned back into `cookie.expires` when connect-redis needs it.  

The session/cookie object already has an `_expires` [property on it](https://github.com/socialtables/session/pull/5/files#diff-cc011139466a177029f576c22ffb7a3141e5b3685aabe791da9a220a15d6043eR60-R62), so we don't have to do anything special to deserialize it. 
